### PR TITLE
Refactor SocketContextProvider to use WebSocket secure URL

### DIFF
--- a/client/src/context/SocketContextProvider.jsx
+++ b/client/src/context/SocketContextProvider.jsx
@@ -4,9 +4,10 @@ import { retrieveEnvironmentVariable } from '../services/RetrieveEnvironmentVari
 import { MessageContext } from './MessageContextProvider';
 import { useMemo } from 'react';
 
-const url = `${retrieveEnvironmentVariable('VITE_BACKEND_URL')}:${retrieveEnvironmentVariable(
-  'VITE_BACKEND_PORT',
-)}`;
+// const url = `${retrieveEnvironmentVariable('VITE_BACKEND_URL')}:${retrieveEnvironmentVariable(
+//   'VITE_BACKEND_PORT',
+// )}`;
+const url = `${retrieveEnvironmentVariable('VITE_BACKEND_URL')}/wss/`;
 const SocketContext = createContext();
 
 const SocketContextProvider = ({ children }) => {


### PR DESCRIPTION
Instead of connecting directly to the backend `http`, connect through the proxy path configured on Apache
May not need VITE_BACKEND_PORT if using the proxy pass setup without specifying a port in the URL